### PR TITLE
v6.0: Events-based

### DIFF
--- a/resources/css/cookie-notice.css
+++ b/resources/css/cookie-notice.css
@@ -1,3 +1,1 @@
-/*@tailwind base;*/
-/* @tailwind components; */
 @tailwind utilities;

--- a/resources/views/scripts.antlers.html
+++ b/resources/views/scripts.antlers.html
@@ -4,10 +4,27 @@
     let hideConsentFormButton = document.getElementById('hideConsentFormButton')
     let manageCookiesButton = document.getElementById('manageCookiesButton')
     let COOKIE_NAME = '{{ cookie_name }}'
-    let groups = JSON.parse('{{ groups | json }}')
+    let consentGroups = JSON.parse('{{ groups | json }}')
 
     window.cookieNotice = {
+        listeners: [],
+
         consentWithCookies: function(groups) {
+            consentGroups.forEach((consentGroup) => {
+                let previousStatus = this.getCookie(COOKIE_NAME).split(',').includes(consentGroup.slug)
+                let currentStatus = groups.includes(consentGroup.slug)
+
+                if (previousStatus !== currentStatus && currentStatus === true) {
+                    this.dispatchEvent('consented', consentGroup)
+                }
+
+                if (previousStatus !== currentStatus && currentStatus === false) {
+                    this.dispatchEvent('revoked', consentGroup)
+                }
+            })
+
+            this.dispatchEvent('consentUpdated', groups)
+
             this.setCookie(COOKIE_NAME, groups, 30)
             this.hideConsentNotice()
         },
@@ -50,26 +67,31 @@
 
             const consented = window.cookieNotice.getCookie(COOKIE_NAME).split(',')
 
-            if (group = groups.find(g => g.name === group)) {
+            if (group = consentGroups.find(g => g.name === group)) {
                 return consented.includes(group.slug)
             }
 
             return consented.length > 0
-        }
+        },
+
+        on: (event, callback) => {
+            cookieNotice.listeners.push({
+                event: event,
+                callback: callback,
+            });
+        },
+
+        dispatchEvent: (event, payload) => {
+            cookieNotice.listeners
+                .filter((listener) => listener.event === event)
+                .forEach((listener) => listener.callback(payload));
+        },
     }
 
     window.addEventListener('load', function() {
         cookiesForm = document.getElementById('cookiesForm')
         hideConsentFormButton = document.getElementById('hideConsentFormButton')
         manageCookiesButton = document.getElementById('manageCookiesButton')
-
-        cookiesForm.addEventListener('submit', function(event) {
-            event.preventDefault()
-            const formData = new FormData(event.target)
-            const groups = formData.getAll('groups')
-
-            window.cookieNotice.consentWithCookies(groups)
-        })
 
         cookiesForm.addEventListener('submit', function(event) {
             event.preventDefault()
@@ -92,6 +114,13 @@
 
         hideConsentFormButton.addEventListener('click', window.cookieNotice.hideConsentNotice)
         manageCookiesButton.addEventListener('click', window.cookieNotice.showConsentNotice)
+
+        window.cookieNotice.dispatchEvent(
+            'loaded',
+            window.cookieNotice.getCookie(COOKIE_NAME).split(',').map((slug) => {
+                return consentGroups.find((group) => group.slug === slug)
+            })
+        )
     })
 </script>
 <!-- End: Cookie Notice scripts -->

--- a/resources/views/scripts.antlers.html
+++ b/resources/views/scripts.antlers.html
@@ -23,8 +23,6 @@
                 }
             })
 
-            this.dispatchEvent('consentUpdated', groups)
-
             this.setCookie(COOKIE_NAME, groups, 30)
             this.hideConsentNotice()
         },


### PR DESCRIPTION
This pull request adds the ability for developers to utilise events to check for user consent, rather than using helper methods. 

This method should hopefully be a little more reliable, in terms of being able to enable/disable third-party tracking scripts straight away after user consent/revoking.

The _old_ API will continue to work as you'd expect (and will do for the foreseeable future). However, any new sites should use the new events system. 

## Code Examples

```html
<script>
  cookieNotice.on('loaded', (groups) => {
      if (groups.find(group) => group.slug === 'group_statistics') {
          // Load Google Analytics... (or something else...)
      }

      if (groups.find(group) => group.slug === 'group_marketing') {
          // Load Facebook Pixel... (or something else...)
      }
  })
</script>
```

```html
<script>
  cookieNotice.on("consented", (group) => {
    if (group.slug === "group_marketing") {
      // Load Facebook Pixel...
    }

    // ...
  });
</script>
```

```html
<script>
  cookieNotice.on("revoked", (group) => {
    if (group.slug === "group_marketing") {
      // Stop Facebook Pixel from tracking the user...
    }

    // ...
  });
</script>
```