### PR TITLE
Update Vite config in ServiceProvider for asset publishing

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -20,7 +20,10 @@ class ServiceProvider extends AddonServiceProvider
     ];
 
     protected $vite = [
-        'resources/css/cookie-notice.css',
+        'publicDirectory' => 'dist',
+        'input' => [
+            'resources/css/cookie-notice.css',
+        ],
     ];
 
     public function boot()


### PR DESCRIPTION
After having the problem from #64 I checked the `AddonServiceProvider` and it looks like the `publicDirectory` is set to `public` if not otherwise specified. I modified the `$vite` property and am no longer getting the error with that modification.