### PR TITLE
Fix file name and path for CSS dist bundle

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -21,6 +21,7 @@ class ServiceProvider extends AddonServiceProvider
 
     protected $vite = [
         'publicDirectory' => 'dist',
+        'buildDirectory' => 'css',
         'input' => [
             'resources/css/cookie-notice.css',
         ],

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,6 +3,7 @@ import laravel from "laravel-vite-plugin";
 
 export default defineConfig({
   build: {
+    manifest: false,
     rollupOptions: {
       output: {
         assetFileNames: '[name][extname]',

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,10 +2,18 @@ import { defineConfig } from "vite";
 import laravel from "laravel-vite-plugin";
 
 export default defineConfig({
+  build: {
+    rollupOptions: {
+      output: {
+        assetFileNames: '[name][extname]',
+      }
+    }
+  },
   plugins: [
     laravel({
       hotFile: "vite.hot",
       publicDirectory: "dist",
+      buildDirectory: "css",
       input: ["resources/css/cookie-notice.css"],
     }),
   ],


### PR DESCRIPTION
Fixes #66. I adapted the Vite config so that the file path matches the one used in releases before switching to vite.