### PR TITLE
Re-add manifest.json

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -21,6 +21,7 @@ class ServiceProvider extends AddonServiceProvider
 
     protected $vite = [
         'publicDirectory' => 'dist',
+        'buildDirectory' => 'css',
         'input' => [
             'resources/css/cookie-notice.css',
         ],

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,7 +3,6 @@ import laravel from "laravel-vite-plugin";
 
 export default defineConfig({
   build: {
-    manifest: false,
     rollupOptions: {
       output: {
         assetFileNames: '[name][extname]',

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,6 +3,7 @@ import laravel from "laravel-vite-plugin";
 
 export default defineConfig({
   build: {
+    manifest: false,
     rollupOptions: {
       output: {
         assetFileNames: '[name][extname]',

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,10 +2,18 @@ import { defineConfig } from "vite";
 import laravel from "laravel-vite-plugin";
 
 export default defineConfig({
+  build: {
+    rollupOptions: {
+      output: {
+        assetFileNames: '[name][extname]',
+      }
+    }
+  },
   plugins: [
     laravel({
       hotFile: "vite.hot",
       publicDirectory: "dist",
+      buildDirectory: "css",
       input: ["resources/css/cookie-notice.css"],
     }),
   ],


### PR DESCRIPTION
I don’t know why that just happens now, but: I get a 500 error saying the `Vite manifest not found` in the admin area. So it seems the `manifest.json` file is needed, and this PR adds it back…