### PR TITLE
bugfix: wrong namespace

### DIFF
--- a/src/Tags/CookieNoticeTag.php
+++ b/src/Tags/CookieNoticeTag.php
@@ -74,7 +74,7 @@ class CookieNoticeTag extends Tags
         }
 
         // Get the CSS from the site's vendor/cookie-notice directory (as otherwise, some ad-blockers will block the styles)
-        $cookieNoticeVersion = Addon::get('duncanmcclean/cookie-notice')->version();
+        $cookieNoticeVersion = Addon::get('doublethreedigital/cookie-notice')->version();
 
         $array['inline_css'] = Cache::rememberForever("CookieNotice:{$cookieNoticeVersion}:InlineCss", function () {
             return File::get(public_path('vendor/cookie-notice/css/cookie-notice.css'));


### PR DESCRIPTION
Changed the namespace to use doublethreedigital instead of duncanmcclean