### PR TITLE
Fix Vite once and for all

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
         "build": "vite build"
     },
     "dependencies": {
+        "autoprefixer": "^10.4.14",
         "cross-env": "^7.0.2",
+        "postcss": "^8.4.23",
         "tailwindcss": "^1.4.6"
     },
     "devDependencies": {

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -19,14 +19,6 @@ class ServiceProvider extends AddonServiceProvider
         UpdateScripts\BreakingChangesWarning::class,
     ];
 
-    protected $vite = [
-        'publicDirectory' => 'dist',
-        'buildDirectory' => 'css',
-        'input' => [
-            'resources/css/cookie-notice.css',
-        ],
-    ];
-
     public function boot()
     {
         parent::boot();

--- a/src/Tags/CookieNoticeTag.php
+++ b/src/Tags/CookieNoticeTag.php
@@ -5,10 +5,12 @@ namespace DuncanMcClean\CookieNotice\Tags;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Vite;
 use Statamic\Facades\Addon;
 use Statamic\Facades\GlobalSet;
 use Statamic\Facades\Site;
 use Statamic\Tags\Tags;
+use Illuminate\Support\Str;
 
 class CookieNoticeTag extends Tags
 {
@@ -77,9 +79,19 @@ class CookieNoticeTag extends Tags
         $cookieNoticeVersion = Addon::get('duncanmcclean/cookie-notice')->version();
 
         $array['inline_css'] = Cache::rememberForever("CookieNotice:{$cookieNoticeVersion}:InlineCss", function () {
-            return File::get(public_path('vendor/cookie-notice/css/cookie-notice.css'));
+            return File::get($this->getViteAssetPath('resources/css/cookie-notice.css', 'vendor/cookie-notice/build'));
         });
 
         return $array;
+    }
+
+    /**
+     * Converts the Vite asset URL to a path on the filesystem.
+     */
+    protected function getViteAssetPath($asset, $buildDirectory = null): string
+    {
+        $url = Vite::asset($asset, $buildDirectory);
+
+        return public_path('vendor/cookie-notice') . '/' . Str::after($url, 'cookie-notice/');
     }
 }

--- a/src/Tags/CookieNoticeTag.php
+++ b/src/Tags/CookieNoticeTag.php
@@ -6,11 +6,11 @@ use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Vite;
+use Illuminate\Support\Str;
 use Statamic\Facades\Addon;
 use Statamic\Facades\GlobalSet;
 use Statamic\Facades\Site;
 use Statamic\Tags\Tags;
-use Illuminate\Support\Str;
 
 class CookieNoticeTag extends Tags
 {
@@ -92,6 +92,6 @@ class CookieNoticeTag extends Tags
     {
         $url = Vite::asset($asset, $buildDirectory);
 
-        return public_path('vendor/cookie-notice') . '/' . Str::after($url, 'cookie-notice/');
+        return public_path('vendor/cookie-notice').'/'.Str::after($url, 'cookie-notice/');
     }
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,19 +2,10 @@ import { defineConfig } from "vite";
 import laravel from "laravel-vite-plugin";
 
 export default defineConfig({
-  build: {
-    manifest: false,
-    rollupOptions: {
-      output: {
-        assetFileNames: '[name][extname]',
-      }
-    }
-  },
   plugins: [
     laravel({
       hotFile: "vite.hot",
       publicDirectory: "dist",
-      buildDirectory: "css",
       input: ["resources/css/cookie-notice.css"],
     }),
   ],


### PR DESCRIPTION
This pull request aims to fix the recent issues relating to Vite once and for all.

* We're no longer registering Vite in the `ServiceProvider`, as that's only required for Vite assets in the Control Panel.
* Fixed an issue where `@tailwind utilities;` wasn't being translated into actual CSS. 
* Fixed an issue in the Cookie Notice tag where it failed to load to Vite asset because it had changed path. 

Fixes #68. Related to #60.