### PR TITLE
Bring back PHP 8.1 compatibility

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.2]
+        php: [8.2, 8.1]
         laravel: [10.*]
         statamic: [^4.0]
         testbench: [8.*]

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         }
     },
     "require": {
-        "php": "^8.2",
+        "php": "^8.1",
         "pixelfear/composer-dist-plugin": "^0.1.5",
         "statamic/cms": "^4.0"
     },


### PR DESCRIPTION
This pull request brings back PHP 8.1 support to Cookie Notice.