### PR TITLE
Fix "toggle by default" causing checkbox to always be checked

### DIFF
--- a/resources/views/notice.antlers.html
+++ b/resources/views/notice.antlers.html
@@ -21,7 +21,7 @@
                     {{ group }}
                         <label class="cookies-mb-1" for="{{ slug }}">
                             <input id="{{ slug }}" type="checkbox" name="groups" value="{{ slug }}"
-                                {{ if toggle_by_default && !cookie || required }} checked {{ /if }}
+                                {{ if toggle_by_default && !cookie || required }} data-toggle-by-default="true" {{ /if }}
                                 {{ if required }} required onclick="this.checked = true" {{ /if }}>
                             {{ trans :key="name" }}
                             {{ if required }}

--- a/resources/views/scripts.antlers.html
+++ b/resources/views/scripts.antlers.html
@@ -29,6 +29,27 @@
         showConsentNotice: function() {
             manageCookiesButton.setAttribute('style', 'display: none;')
             cookiesForm.removeAttribute('style')
+
+            // Figure out which checkboxes should be checked by default.
+            // https://github.com/duncanmcclean/cookie-notice/issues/77
+            consentGroups.forEach((consentGroup) => {
+                let checkbox = document.getElementById(consentGroup.slug)
+
+                if (window.cookieNotice.hasConsentedToSomething())  {
+                    if (window.cookieNotice.hasConsent(consentGroup.slug)) {
+                        console.log('has consent for ' + consentGroup.slug)
+                        return checkbox.checked = true
+                    }
+
+                    return;
+                }
+
+                if (checkbox.dataset.toggleByDefault === 'true') {
+                    console.log('toggle by default for ' + consentGroup.slug)
+
+                    return checkbox.checked = true
+                }
+            })
         },
 
         hideConsentNotice: function() {
@@ -64,11 +85,17 @@
 
             const consented = window.cookieNotice.getCookie(COOKIE_NAME).split(',')
 
-            if (group = consentGroups.find(g => g.name === group)) {
-                return consented.includes(group.slug)
+            return consented.includes(group);
+        },
+
+        hasConsentedToSomething: function() {
+            if (window.cookieNotice.getCookie(COOKIE_NAME) === undefined) {
+                return false
             }
 
-            return consented.length > 0
+            const consented = window.cookieNotice.getCookie(COOKIE_NAME).split(',')
+
+            return consented.length > 0;
         },
 
         on: (event, callback) => {


### PR DESCRIPTION
This pull request attempts to fix an issue where the "toggle by default" configuration option was causing checkboxes to always be checked, even if the user had previously unchecked the consent group.

This was happening as it was defaulting to `checked` as long as the "toggle by default" setting was active. It wasn't checking if the user had an existing cookie containing their consent preferences (which it is now, in this PR).

Fixes #77