### PR TITLE
[9.x] Statamic 5

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,10 +12,9 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.2, 8.1]
-        laravel: [10.*]
-        statamic: [^4.0]
-        testbench: [8.*]
+        php: [8.1, 8.2, 8.3]
+        laravel: [11.*, 10.*]
+        statamic: [^5.0]
         os: [ubuntu-latest]
 
     name: ${{ matrix.php }} - ${{ matrix.statamic }} - ${{ matrix.laravel }}
@@ -33,8 +32,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "statamic/cms:${{ matrix.statamic }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" "statamic/cms:${{ matrix.statamic }}" --no-interaction --no-update
           composer install --no-interaction
 
       - name: Run PHPUnit
-        run: composer test
+        run: vendor/bin/pest

--- a/composer.json
+++ b/composer.json
@@ -30,19 +30,11 @@
     "require": {
         "php": "^8.1",
         "pixelfear/composer-dist-plugin": "^0.1.5",
-        "statamic/cms": "^4.0"
+        "statamic/cms": "^5.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^7.0",
-        "pestphp/pest": "^1.22"
-    },
-    "scripts": {
-        "lint": [
-            "php-cs-fixer fix ./src"
-        ],
-        "test": [
-            "./vendor/bin/pest"
-        ]
+        "orchestra/testbench": "^8.0 || ^9.0",
+        "pestphp/pest": "^2.2"
     },
     "config": {
         "optimize-autoloader": true,
@@ -53,5 +45,5 @@
             "pestphp/pest-plugin": true
         }
     },
-    "minimum-stability": "alpha"
+    "minimum-stability": "dev"
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,29 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
-    <testsuites>
-        <testsuite name="Test Suite">
-            <directory suffix="Test.php">./tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./app</directory>
-        </whitelist>
-    </filter>
-    <php>
-        <env name="APP_ENV" value="testing"/>
-        <env name="APP_KEY" value="base64:xRIcDp1ReW8Y8rd9V9D7hOVV4TI7ThCF3FKxRg01Rm8="/>
-        <env name="CACHE_DRIVER" value="array"/>
-        <env name="SESSION_DRIVER" value="array"/>
-        <env name="QUEUE_DRIVER" value="sync"/>
-        <env name="MAIL_DRIVER" value="array"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+  <testsuites>
+    <testsuite name="Test Suite">
+      <directory suffix="Test.php">./tests</directory>
+    </testsuite>
+  </testsuites>
+  <php>
+    <env name="APP_ENV" value="testing"/>
+    <env name="APP_KEY" value="base64:xRIcDp1ReW8Y8rd9V9D7hOVV4TI7ThCF3FKxRg01Rm8="/>
+    <env name="CACHE_DRIVER" value="array"/>
+    <env name="SESSION_DRIVER" value="array"/>
+    <env name="QUEUE_DRIVER" value="sync"/>
+    <env name="MAIL_DRIVER" value="array"/>
+  </php>
+  <source>
+    <include>
+      <directory suffix=".php">./app</directory>
+    </include>
+  </source>
 </phpunit>

--- a/src/Tags/CookieNoticeTag.php
+++ b/src/Tags/CookieNoticeTag.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Vite;
+use Illuminate\Support\Str;
 use Statamic\Facades\Addon;
 use Statamic\Facades\GlobalSet;
 use Statamic\Facades\Site;
@@ -35,7 +36,7 @@ class CookieNoticeTag extends Tags
             ->map(function ($value, $key) {
                 return array_merge($value, [
                     'name' => $key,
-                    'slug' => 'group_'.str_slug($key),
+                    'slug' => 'group_'.Str::slug($key),
                 ]);
             })
             ->values()

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,53 +3,9 @@
 namespace DuncanMcClean\CookieNotice\Tests;
 
 use DuncanMcClean\CookieNotice\ServiceProvider;
-use Orchestra\Testbench\TestCase as OrchestraTestCase;
-use Statamic\Extend\Manifest;
-use Statamic\Providers\StatamicServiceProvider;
-use Statamic\Statamic;
+use Statamic\Testing\AddonTestCase;
 
-abstract class TestCase extends OrchestraTestCase
+abstract class TestCase extends AddonTestCase
 {
-    protected function getPackageProviders($app)
-    {
-        return [
-            StatamicServiceProvider::class,
-            ServiceProvider::class,
-        ];
-    }
-
-    protected function getPackageAliases($app)
-    {
-        return [
-            'Statamic' => Statamic::class,
-        ];
-    }
-
-    protected function getEnvironmentSetUp($app)
-    {
-        parent::getEnvironmentSetUp($app);
-
-        $app->make(Manifest::class)->manifest = [
-            'duncanmcclean/cookie-notice' => [
-                'id' => 'duncanmcclean/cookie-notice',
-                'namespace' => 'DuncanMcClean\\CookieNotice',
-            ],
-        ];
-    }
-
-    protected function resolveApplicationConfiguration($app)
-    {
-        parent::resolveApplicationConfiguration($app);
-
-        $configs = [
-            'assets', 'cp', 'forms', 'static_caching',
-            'sites', 'stache', 'system', 'users',
-        ];
-
-        foreach ($configs as $config) {
-            $app['config']->set("statamic.$config", require(__DIR__."/../vendor/statamic/cms/config/{$config}.php"));
-        }
-
-        $app['config']->set('statamic.users.repository', 'file');
-    }
+    protected string $addonServiceProvider = ServiceProvider::class;
 }


### PR DESCRIPTION
This pull request makes the necessary changes required to support Statamic 5.

## Changes

* Updates the version constraint in `composer.json` 
* Adjusted testing matrix
* Simplifies the `TestCase`
    * This was made possible by https://github.com/statamic/cms/pull/9573.
* Replaced `str_slug()` with `Str::slug()`
    * Statamic 5 removed its `laravel/helpers` dependency, which is where the `str_slug` method came from.
* Updated to PHPUnit 10