### PR TITLE
Supports Laravel 12

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         php: [8.2, 8.3, 8.4]
-        laravel: [10.*, 11.*]
+        laravel: [10.*, 11.*, 12.*]
         stability: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest]
         exclude:

--- a/composer.json
+++ b/composer.json
@@ -33,9 +33,9 @@
         "statamic/cms": "^5.41"
     },
     "require-dev": {
-        "orchestra/testbench": "^8.28 || ^9.6.1",
-        "pestphp/pest": "^2.2",
-        "pestphp/pest-plugin-laravel": "2.x-dev"
+        "orchestra/testbench": "^8.28 || ^9.6.1 || ^10.0",
+        "pestphp/pest": "^2.2 || ^3.0",
+        "pestphp/pest-plugin-laravel": "^2.0 || ^3.0"
     },
     "config": {
         "optimize-autoloader": true,


### PR DESCRIPTION
This pull request adds Laravel 12 support to `duncanmcclean/cookie-notice`.

Depends on:

* [x] https://github.com/statamic/cms/pull/11433