### PR TITLE
Add config option to disable a consent group checkbox

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -41,6 +41,7 @@ You can customize the consent groups in the `config/cookie-notice.php` config fi
             'name' => 'Necessary',
             'handle' => 'necessary',
             'enable_by_default' => true,
+            'checkbox_disabled' => true,
         ],
         [
             'name' => 'Analytics',
@@ -57,6 +58,7 @@ For each consent group, you can provide the following options:
 * `handle` - The handle will be used as a unique identifier for this consent group.
 * `description` - Optional. The description will be displayed alongside the group's name.
 * `enable_by_default` - Optional. Determines whether the consent group will be enabled by default when users first visit your site. They'll still be able to disable the consent group if they wish.
+* `checkbox_disabled` - Optional. Determines whether the consent group checkbox is disabled.
 
 ## Managing Scripts
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -58,7 +58,7 @@ For each consent group, you can provide the following options:
 * `handle` - The handle will be used as a unique identifier for this consent group.
 * `description` - Optional. The description will be displayed alongside the group's name.
 * `enable_by_default` - Optional. Determines whether the consent group will be enabled by default when users first visit your site. They'll still be able to disable the consent group if they wish.
-* `checkbox_disabled` - Optional. Determines whether the consent group checkbox is disabled.
+* `checkbox_disabled` - Optional. Prevents users from toggling the consent group's checkbox. The consent group will always be consented to, which is useful for strictly necessary cookies.
 
 ## Managing Scripts
 

--- a/config/cookie-notice.php
+++ b/config/cookie-notice.php
@@ -43,6 +43,7 @@ return [
             'name' => 'Necessary',
             'handle' => 'necessary',
             'enable_by_default' => true,
+            'checkbox_disabled' => true,
         ],
         [
             'name' => 'Analytics',

--- a/resources/js/cookie-notice.js
+++ b/resources/js/cookie-notice.js
@@ -57,6 +57,10 @@ window.CookieNotice = {
             ? JSON.parse(this.getCookie(this.config.cookie_name))
             : null
 
+        this.config.consent_groups
+            .filter((consentGroup) => consentGroup.checkbox_disabled)
+            .forEach((consentGroup) => this.widget.querySelector(`[name="group-${consentGroup.handle}"]`).disabled = true)
+
         if (preferences && preferences.revision === this.config.revision) {
             this.hideWidget()
 
@@ -64,21 +68,19 @@ window.CookieNotice = {
                 let preference = preferences.consent.find((preference) => preference.handle === consentGroup.handle)
 
                 if (preference) {
-                    this.widget.querySelector(`[name="group-${consentGroup.handle}"]`).checked = preference.value
-                    this.widget.querySelector(`[name="group-${consentGroup.handle}"]`).disabled = !!consentGroup.checkbox_disabled
+                    let checked = consentGroup.checkbox_disabled ? true : preference.value
 
-                    preference.value
+                    this.widget.querySelector(`[name="group-${consentGroup.handle}"]`).checked = checked
+
+                    checked
                         ? this.dispatchEvent('accepted', consentGroup.handle)
                         : this.dispatchEvent('declined', consentGroup.handle)
                 }
             });
         } else {
             this.config.consent_groups
-                .filter((consentGroup) => consentGroup.enable_by_default)
+                .filter((consentGroup) => consentGroup.enable_by_default || consentGroup.checkbox_disabled)
                 .forEach((consentGroup) => this.widget.querySelector(`[name="group-${consentGroup.handle}"]`).checked = true)
-            this.config.consent_groups
-                .filter((consentGroup) => consentGroup.checkbox_disabled)
-                .forEach((consentGroup) => this.widget.querySelector(`[name="group-${consentGroup.handle}"]`).disabled = true)
         }
     },
 
@@ -100,7 +102,9 @@ window.CookieNotice = {
             consent: this.config.consent_groups.map((consentGroup) => {
                 return {
                     handle: consentGroup.handle,
-                    value: this.widget.querySelector(`[name="group-${consentGroup.handle}"]`).checked ? true : false
+                    value: consentGroup.checkbox_disabled
+                        ? true
+                        : this.widget.querySelector(`[name="group-${consentGroup.handle}"]`).checked
                 }
             })
         }

--- a/resources/js/cookie-notice.js
+++ b/resources/js/cookie-notice.js
@@ -65,6 +65,7 @@ window.CookieNotice = {
 
                 if (preference) {
                     this.widget.querySelector(`[name="group-${consentGroup.handle}"]`).checked = preference.value
+                    this.widget.querySelector(`[name="group-${consentGroup.handle}"]`).disabled = !!consentGroup.checkbox_disabled
 
                     preference.value
                         ? this.dispatchEvent('accepted', consentGroup.handle)
@@ -75,6 +76,9 @@ window.CookieNotice = {
             this.config.consent_groups
                 .filter((consentGroup) => consentGroup.enable_by_default)
                 .forEach((consentGroup) => this.widget.querySelector(`[name="group-${consentGroup.handle}"]`).checked = true)
+            this.config.consent_groups
+                .filter((consentGroup) => consentGroup.checkbox_disabled)
+                .forEach((consentGroup) => this.widget.querySelector(`[name="group-${consentGroup.handle}"]`).disabled = true)
         }
     },
 

--- a/resources/views/widget.antlers.html
+++ b/resources/views/widget.antlers.html
@@ -10,7 +10,7 @@
                 {{ consent_groups }}
                     <li class="cn:flex cn:items-start cn:gap-x-3">
                         <div class="cn:flex cn:mt-2">
-                            <input id="group-{{ handle }}" aria-describedby="group-{{ handle }}-description" name="group-{{ handle }}" type="checkbox" class="cn:h-4 cn:w-4 cn:rounded cn:border-gray-300 cn:text-blue-600 cn:focus:ring-indigo-600">
+                            <input id="group-{{ handle }}" aria-describedby="group-{{ handle }}-description" name="group-{{ handle }}" type="checkbox" class="cn:h-4 cn:w-4 cn:rounded cn:border-gray-300 cn:text-blue-600 cn:focus:ring-indigo-600" {{ checkbox_disabled ?= "disabled" }}>
                         </div>
                         <div class="cn:flex cn:flex-col">
                             <label for="group-{{ handle }}" class="cn:font-semibold cn:select-none">{{ name }}</label>

--- a/src/Rules/ValidInlineJavaScript.php
+++ b/src/Rules/ValidInlineJavaScript.php
@@ -10,11 +10,13 @@ class ValidInlineJavaScript implements ValidationRule
 {
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
-        if (is_null($value) || is_null($value['code'])) {
+        $code = is_array($value) ? $value['code'] ?? null : $value;
+
+        if (is_null($code)) {
             return;
         }
 
-        if (Str::contains($value['code'], '<script')) {
+        if (Str::contains($code, '<script')) {
             $fail('This field must not contain `<script>` tags.')->translate();
         }
     }

--- a/tests/Tags/CookieNoticeTagTest.php
+++ b/tests/Tags/CookieNoticeTagTest.php
@@ -15,6 +15,14 @@ it('renders the cookie consent widget', function () {
         ->toContain('window.CookieNotice.boot(');
 });
 
+it('disables checkboxes for consent groups with checkbox_disabled', function () {
+    $html = (string) Parse::template('<body>{{ cookie_notice:widget }}</body>', trusted: true);
+
+    expect($html)
+        ->toMatch('/name="group-necessary"[^>]*disabled/')
+        ->not->toMatch('/name="group-analytics"[^>]*disabled/');
+});
+
 it('renders the cookie consent widget using a custom view', function () {
     Config::set('cookie-notice.widget_view', 'partials.custom-cookie-notice-widget');
     File::put(resource_path('views/partials/custom-cookie-notice-widget.antlers.html'), '<div>Custom Cookie Notice Widget</div>');


### PR DESCRIPTION
This pull request adds a config option for checkbox_disabled to disable the checkbox in the widget. It addresses the issue where Necessary concent group could be disabled in the widget
<img width="492" height="404" alt="necessary_checkbox_disabled" src="https://github.com/user-attachments/assets/76ebba89-ed92-4a20-a205-21b0303429da" />
 