### PR TITLE
Add support for multiple data-show-cookie-notice-widget buttons on page

### DIFF
--- a/resources/js/cookie-notice.js
+++ b/resources/js/cookie-notice.js
@@ -13,7 +13,13 @@ window.CookieNotice = {
         this.initPreferences()
 
         this.widget.querySelector('[data-save-preferences]').addEventListener('click', this.savePreferences.bind(this))
-        document.querySelector('[data-show-cookie-notice-widget]')?.addEventListener('click', this.showWidget.bind(this))
+        document.addEventListener('click', (e) => {
+            const trigger = e.target.closest('[data-show-cookie-notice-widget]')
+            if (trigger) {
+                e.preventDefault()
+                this.showWidget()
+            }
+        })
     },
 
     hideWidget() {


### PR DESCRIPTION
When more than one button with `data-show-cookie-notice-widget` attribute  is on the page, the widget will trigger when any trigger button is clicked

I have a "Update Preferences" button in my footer on every page. When cookie is declined I use a place holder that explains the content is disabled and add an second "Update Preferences" button. This ensures all buttons function and not just the first one rendered.