### PR TITLE
Fix widget from flashing on page load when preferences are already set

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -174,7 +174,7 @@ If you'd prefer to build your own consent widget, to gain more control over the 
 3. Next, copy this boilerplate into your new view:
     ```antlers
     <!-- Start of Cookie Notice Widget -->
-    <div id="cookie-notice" class="relative z-[999]">
+    <div id="cookie-notice" class="relative z-[999]; display: none">
         <div class="fixed bottom-6 right-6 bg-white p-6 sm:mx-auto sm:max-w-lg">
             <h2>This site uses cookies</h2>
             <ul>

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -174,7 +174,7 @@ If you'd prefer to build your own consent widget, to gain more control over the 
 3. Next, copy this boilerplate into your new view:
     ```antlers
     <!-- Start of Cookie Notice Widget -->
-    <div id="cookie-notice" class="relative z-[999]; display: none">
+    <div id="cookie-notice" class="relative z-[999]" style="display: none">
         <div class="fixed bottom-6 right-6 bg-white p-6 sm:mx-auto sm:max-w-lg">
             <h2>This site uses cookies</h2>
             <ul>

--- a/resources/js/cookie-notice.js
+++ b/resources/js/cookie-notice.js
@@ -84,6 +84,8 @@ window.CookieNotice = {
                 }
             });
         } else {
+            this.showWidget()
+
             this.config.consent_groups
                 .filter((consentGroup) => consentGroup.enable_by_default || consentGroup.checkbox_disabled)
                 .forEach((consentGroup) => this.widget.querySelector(`[name="group-${consentGroup.handle}"]`).checked = true)

--- a/resources/views/widget.antlers.html
+++ b/resources/views/widget.antlers.html
@@ -1,7 +1,7 @@
 <!-- Start of Cookie Notice Widget -->
 <style>{{ inline_css }}</style>
 
-<div id="cookie-notice" class="cn:relative cn:font-sans" style="z-index: 999">
+<div id="cookie-notice" class="cn:relative cn:font-sans" style="z-index: 999; display: none">
     <div class="cn:fixed cn:bottom-6 cn:right-6 cn:bg-white cn:ml-4 cn:px-4 cn:py-8 cn:shadow-xl cn:ring-1 cn:ring-gray-900/5 cn:sm:mx-auto cn:sm:max-w-lg cn:sm:rounded-lg cn:sm:px-10">
         <div class="cn:space-y-2 cn:text-base cn:leading-7 cn:text-gray-600">
             <h2 class="cn:text-2xl cn:font-bold">{{ trans key="This site uses cookies" }}</h2>


### PR DESCRIPTION
The widget will briefly flash on page load. This addresses the issue by setting the default style to `display: none` on the widget and only showing it when necessary.